### PR TITLE
Readme pointer to Wiki work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # nupic.audio
-Audio (analog, digital) experiments using NuPIC HTM/CLA
+Auditory experiments using NuPIC HTM/CLA
+
+Initial thoughts and ideas are being discussed in the Wiki at the moment;  
+https://github.com/nupic-community/nupic.audio/wiki


### PR DESCRIPTION
Change to main Readme.md to direct people into the Wiki discussions.
